### PR TITLE
Use setuptools vs deprecated distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
-from distutils.core import setup
+# from distutils.core import setup
+from setuptools import setup
+
 
 setup(
     name='kairos_face_recognition_lib',


### PR DESCRIPTION
One-line change to use setuptools. This allows a wheel package to be cleanly built.